### PR TITLE
ルート削除機能の改善 - 確認ダイアログとアイコンの見直し

### DIFF
--- a/src/components/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog.tsx
@@ -1,0 +1,110 @@
+import { Fragment } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+
+interface ConfirmationDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+  title: string
+  message: string
+  confirmText?: string
+  cancelText?: string
+  variant?: 'danger' | 'warning' | 'info'
+}
+
+export default function ConfirmationDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmText = '確認',
+  cancelText = 'キャンセル',
+  variant = 'danger'
+}: ConfirmationDialogProps) {
+  const iconColorClass = {
+    danger: 'text-red-600',
+    warning: 'text-yellow-600',
+    info: 'text-blue-600'
+  }[variant]
+
+  const buttonColorClass = {
+    danger: 'bg-red-600 hover:bg-red-700 focus:ring-red-500',
+    warning: 'bg-yellow-600 hover:bg-yellow-700 focus:ring-yellow-500',
+    info: 'bg-blue-600 hover:bg-blue-700 focus:ring-blue-500'
+  }[variant]
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                <div className="flex items-start">
+                  <div className={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 ${iconColorClass}`}>
+                    <ExclamationTriangleIcon className="h-6 w-6" aria-hidden="true" />
+                  </div>
+                  <div className="ml-4 flex-1">
+                    <Dialog.Title
+                      as="h3"
+                      className="text-lg font-medium leading-6 text-gray-900"
+                    >
+                      {title}
+                    </Dialog.Title>
+                    <div className="mt-2">
+                      <p className="text-sm text-gray-500">
+                        {message}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+                  <button
+                    type="button"
+                    className={`inline-flex w-full justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm sm:ml-3 sm:w-auto ${buttonColorClass}`}
+                    onClick={() => {
+                      onConfirm()
+                      onClose()
+                    }}
+                  >
+                    {confirmText}
+                  </button>
+                  <button
+                    type="button"
+                    className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+                    onClick={onClose}
+                  >
+                    {cancelText}
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}

--- a/src/components/controls/RouteActions.tsx
+++ b/src/components/controls/RouteActions.tsx
@@ -1,19 +1,41 @@
+import { useState } from 'react'
 import { useRouteStore } from '../../store/routeStore'
 import { downloadGPX } from '../../utils/gpx'
-import { TrashIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline'
+import { XMarkIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline'
+import ConfirmationDialog from '../ConfirmationDialog'
 
 export default function RouteActions() {
   const { route, clearRoute } = useRouteStore()
   const hasRoute = route.points.length > 0
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   
   const handleExportGPX = () => {
     downloadGPX(route.points)
   }
   
+  const handleClearRoute = () => {
+    setShowConfirmDialog(true)
+  }
+  
+  const confirmClearRoute = () => {
+    clearRoute()
+    setShowConfirmDialog(false)
+  }
+  
   return (
     <>
+      <ConfirmationDialog
+        isOpen={showConfirmDialog}
+        onClose={() => setShowConfirmDialog(false)}
+        onConfirm={confirmClearRoute}
+        title="ルートをクリアしますか？"
+        message="この操作は取り消すことができません。現在のルートがすべて削除されます。"
+        confirmText="クリア"
+        cancelText="キャンセル"
+        variant="danger"
+      />
       <button
-        onClick={clearRoute}
+        onClick={handleClearRoute}
         disabled={!hasRoute}
         className={`
           p-3 bg-white rounded-lg shadow-lg transition-all
@@ -22,9 +44,9 @@ export default function RouteActions() {
             : 'text-gray-300 cursor-not-allowed'
           }
         `}
-        title="Clear route"
+        title="ルートをクリア"
       >
-        <TrashIcon className="w-5 h-5" />
+        <XMarkIcon className="w-5 h-5" />
       </button>
       
       <button
@@ -37,7 +59,7 @@ export default function RouteActions() {
             : 'text-gray-300 cursor-not-allowed'
           }
         `}
-        title="Export GPX"
+        title="GPXファイルをエクスポート"
       >
         <ArrowDownTrayIcon className="w-5 h-5" />
       </button>


### PR DESCRIPTION
## 概要
- ルート削除時に確認ダイアログを表示するように改善
- より直感的なUIのためアイコンとラベルを変更
- 誤操作防止のためのUX改善

## 変更内容
### 1. 確認ダイアログの実装
- HeadlessUIを使用した再利用可能な`ConfirmationDialog`コンポーネントを作成
- 削除前に「ルートをクリアしますか？」という確認メッセージを表示

### 2. アイコンの変更
- ゴミ箱アイコン（TrashIcon）から×マーク（XMarkIcon）に変更
- 「削除」ではなく「クリア」のアクションをより適切に表現

### 3. ラベルの改善
- ツールチップを英語から日本語に変更
- 「Clear route」→「ルートをクリア」
- 「Export GPX」→「GPXファイルをエクスポート」

## テスト計画
- [x] ルートが存在しない時、クリアボタンが無効化されていることを確認
- [x] ルートが存在する時、クリアボタンをクリックすると確認ダイアログが表示されることを確認
- [x] 確認ダイアログで「キャンセル」を選択すると、ルートが削除されないことを確認
- [x] 確認ダイアログで「クリア」を選択すると、ルートが削除されることを確認
- [x] ビルドが正常に完了することを確認
- [ ] リントチェックが通ることを確認

## 関連Issue
- #9

🤖 Generated with [Claude Code](https://claude.ai/code)