### PR TITLE
GitHub ActionsデプロイでMapTiler APIキー環境変数を設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
         run: pnpm build
         env:
           NODE_ENV: production
+          VITE_MAPTILER_KEY: ${{ secrets.VITE_MAPTILER_KEY }}
           
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## 概要
- GitHub ActionsのデプロイワークフローにMapTiler APIキーの環境変数設定を追加
- `VITE_MAPTILER_KEY`をGitHub Secretsから取得してビルド時に設定
- 地図スタイル切り替え機能でMapTilerのスタイルが正常に動作するように対応

## テスト計画
- [ ] GitHub Secretsに`VITE_MAPTILER_KEY`を設定
- [ ] mainブランチへのマージ後、GitHub Actionsのビルドが成功することを確認
- [ ] デプロイされたサイトで地図スタイル切り替えが正常に動作することを確認

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)