### PR TITLE
範囲削除モードのボタンによる解除が動作しない問題を修正

### DIFF
--- a/src/components/MapControls.tsx
+++ b/src/components/MapControls.tsx
@@ -20,7 +20,7 @@ export default function MapControls() {
       </div>
       
       {/* Right side controls */}
-      <div className="absolute right-4 top-1/2 -translate-y-1/2 flex flex-col gap-2">
+      <div className="absolute right-4 top-1/2 -translate-y-1/2 flex flex-col gap-2 z-20">
         <EditControls />
         <DeleteModeControls />
         <RangeDeleteControls />


### PR DESCRIPTION
## 概要
範囲削除モードのボタン（ViewfinderCircleIcon）をクリックしてもモードが解除されない問題を修正しました。

### 問題の原因
- SelectionOverlay（z-10）が右側のコントロールパネルよりも上に表示されていた
- これによりボタンのクリックイベントがオーバーレイにブロックされていた

### 修正内容
- 右側のコントロールパネルに`z-20`クラスを追加
- これによりボタンがSelectionOverlayの上に表示されるようになった

## テスト計画
- [x] 範囲削除ボタンをクリックして範囲削除モードに切り替わることを確認
- [x] 同じボタンを再度クリックして通常モード（view）に戻ることを確認
- [x] ESCキーでも引き続き解除できることを確認
- [x] 他のコントロールボタン（編集、削除など）が正常に動作することを確認

Fixes #31

🤖 Generated with [Claude Code](https://claude.ai/code)