### PR TITLE
feat: Waypointに開始地点からの距離を表示する機能を追加

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react'
 import { MapRef } from 'react-map-gl/maplibre'
 import { useMapHandlers } from '@/hooks/useMapHandlers'
+import { useInitializeWaypointDistances } from '@/hooks/useInitializeWaypointDistances'
 import MapControls from '@/components/MapControls'
 import MapContainer from '@/components/map/MapContainer'
 import RouteLine from '@/components/map/RouteLine'
@@ -12,6 +13,9 @@ import WaypointDialog from '@/components/WaypointDialog'
 
 export default function MapComponent() {
   const mapRef = useRef<MapRef>(null)
+  
+  // 既存のWaypointの距離を初期化
+  useInitializeWaypointDistances()
   
   const {
     handleMapClick,

--- a/src/components/WaypointDialog.tsx
+++ b/src/components/WaypointDialog.tsx
@@ -79,7 +79,8 @@ export default function WaypointDialog() {
         lng: pendingWaypoint.lng,
         name: formData.name,
         description: formData.description || undefined,
-        type: formData.type
+        type: formData.type,
+        nearestPointIndex: pendingWaypoint.nearestPointIndex
       })
     }
     
@@ -122,6 +123,19 @@ export default function WaypointDialog() {
           <h2 className="text-xl font-bold mb-4">
             {isEditMode ? 'Waypointを編集' : 'Waypointを追加'}
           </h2>
+          
+          {/* 距離情報 */}
+          {(selectedWaypoint?.distanceFromStart !== undefined || 
+            (pendingWaypoint && pendingWaypoint.nearestPointIndex !== undefined)) && (
+            <div className="mb-4 p-3 bg-gray-50 rounded-lg">
+              <p className="text-sm text-gray-600">
+                開始地点からの距離: 
+                <span className="font-semibold ml-1">
+                  {selectedWaypoint?.distanceFromStart?.toFixed(1) || '計算中...'}km
+                </span>
+              </p>
+            </div>
+          )}
           
           {/* 名前入力 */}
           <div className="mb-4">

--- a/src/components/map/WaypointMarkers.tsx
+++ b/src/components/map/WaypointMarkers.tsx
@@ -96,6 +96,9 @@ function WaypointMarker({ waypoint }: { waypoint: Waypoint }) {
             {waypoint.elevation && (
               <p className="text-xs text-gray-500 mt-1">標高: {waypoint.elevation.toFixed(1)}m</p>
             )}
+            {waypoint.distanceFromStart !== undefined && (
+              <p className="text-xs text-gray-500 mt-1">開始地点から: {waypoint.distanceFromStart.toFixed(1)}km</p>
+            )}
           </div>
         </Popup>
       )}

--- a/src/components/map/WaypointMarkers.tsx
+++ b/src/components/map/WaypointMarkers.tsx
@@ -55,6 +55,14 @@ function WaypointMarker({ waypoint }: { waypoint: Waypoint }) {
   const selectedWaypointId = useUIStore((state) => state.selectedWaypointId)
   const [showPopup, setShowPopup] = useState(false)
   
+  // デバッグ用
+  console.log('Rendering waypoint:', {
+    id: waypoint.id,
+    name: waypoint.name,
+    nearestPointIndex: waypoint.nearestPointIndex,
+    distanceFromStart: waypoint.distanceFromStart
+  })
+  
   const {
     isDragging,
     canDrag,

--- a/src/hooks/useInitializeWaypointDistances.ts
+++ b/src/hooks/useInitializeWaypointDistances.ts
@@ -10,13 +10,17 @@ export function useInitializeWaypointDistances() {
   const updateWaypointDistances = useRouteStore((state) => state.updateWaypointDistances)
   
   useEffect(() => {
-    // ルートとWaypointが存在し、距離情報がないWaypointがある場合
-    const hasUninitializedWaypoints = waypoints.some(
-      w => w.nearestPointIndex !== undefined && w.distanceFromStart === undefined
-    )
+    // デバッグログ
+    console.log('Initializing waypoint distances...', {
+      routePoints: route.points.length,
+      waypoints: waypoints.length,
+      waypointsData: waypoints
+    })
     
-    if (route.points.length >= 2 && waypoints.length > 0 && hasUninitializedWaypoints) {
+    // ルートとWaypointが存在する場合
+    if (route.points.length >= 2 && waypoints.length > 0) {
+      console.log('Updating waypoint distances...')
       updateWaypointDistances()
     }
-  }, []) // 初回マウントのみ実行
+  }, [route.points.length, waypoints.length]) // ルートやWaypointが変更されたら実行
 }

--- a/src/hooks/useInitializeWaypointDistances.ts
+++ b/src/hooks/useInitializeWaypointDistances.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { useRouteStore } from '@/store/routeStore'
+
+/**
+ * アプリケーション起動時に既存のWaypointの距離を初期化する
+ */
+export function useInitializeWaypointDistances() {
+  const route = useRouteStore((state) => state.route)
+  const waypoints = useRouteStore((state) => state.waypoints)
+  const updateWaypointDistances = useRouteStore((state) => state.updateWaypointDistances)
+  
+  useEffect(() => {
+    // ルートとWaypointが存在し、距離情報がないWaypointがある場合
+    const hasUninitializedWaypoints = waypoints.some(
+      w => w.nearestPointIndex !== undefined && w.distanceFromStart === undefined
+    )
+    
+    if (route.points.length >= 2 && waypoints.length > 0 && hasUninitializedWaypoints) {
+      updateWaypointDistances()
+    }
+  }, []) // 初回マウントのみ実行
+}

--- a/src/hooks/useInitializeWaypointDistances.ts
+++ b/src/hooks/useInitializeWaypointDistances.ts
@@ -10,16 +10,8 @@ export function useInitializeWaypointDistances() {
   const updateWaypointDistances = useRouteStore((state) => state.updateWaypointDistances)
   
   useEffect(() => {
-    // デバッグログ
-    console.log('Initializing waypoint distances...', {
-      routePoints: route.points.length,
-      waypoints: waypoints.length,
-      waypointsData: waypoints
-    })
-    
     // ルートとWaypointが存在する場合
     if (route.points.length >= 2 && waypoints.length > 0) {
-      console.log('Updating waypoint distances...')
       updateWaypointDistances()
     }
   }, [route.points.length, waypoints.length]) // ルートやWaypointが変更されたら実行

--- a/src/hooks/useInitializeWaypointDistances.ts
+++ b/src/hooks/useInitializeWaypointDistances.ts
@@ -12,7 +12,13 @@ export function useInitializeWaypointDistances() {
   useEffect(() => {
     // ルートとWaypointが存在する場合
     if (route.points.length >= 2 && waypoints.length > 0) {
-      updateWaypointDistances()
+      // 距離が未計算のWaypointがあるかチェック
+      const hasUninitializedWaypoints = waypoints.some(
+        w => w.distanceFromStart === undefined
+      )
+      if (hasUninitializedWaypoints) {
+        updateWaypointDistances()
+      }
     }
-  }, [route.points.length, waypoints.length]) // ルートやWaypointが変更されたら実行
+  }, [route.points.length, waypoints, updateWaypointDistances]) // Waypointの内容が変更されたら実行
 }

--- a/src/hooks/useWaypointDrag.ts
+++ b/src/hooks/useWaypointDrag.ts
@@ -24,6 +24,16 @@ export function useWaypointDrag({ waypoint }: UseWaypointDragProps) {
   const handleDrag = useCallback((e: any) => {
     const { lngLat } = e
     
+    // ルートが存在しない場合は、自由に移動
+    if (route.points.length < 2) {
+      updateWaypoint(waypoint.id, {
+        lat: lngLat.lat,
+        lng: lngLat.lng,
+        nearestPointIndex: undefined
+      })
+      return
+    }
+    
     // ルート上の最も近い点を計算
     const closestPoint = findClosestPointOnRoute(
       lngLat.lat,

--- a/src/hooks/useWaypointHandlers.ts
+++ b/src/hooks/useWaypointHandlers.ts
@@ -33,7 +33,8 @@ export function useWaypointHandlers({ mapRef }: UseWaypointHandlersProps) {
       // 計算された点にWaypointを配置
       setPendingWaypoint({
         lat: closestPoint.lat,
-        lng: closestPoint.lng
+        lng: closestPoint.lng,
+        nearestPointIndex: closestPoint.nearestPointIndex
       })
       setWaypointDialogOpen(true)
     }

--- a/src/store/routeStore.ts
+++ b/src/store/routeStore.ts
@@ -233,6 +233,11 @@ export const useRouteStore = create<RouteState>((set, get) => ({
           if (updates.nearestPointIndex !== undefined && state.route.points.length >= 2) {
             const distanceFromStart = calculateDistanceToIndex(state.route.points, updates.nearestPointIndex)
             updatedWaypoint.distanceFromStart = distanceFromStart
+            console.log('Updated waypoint distance:', {
+              waypointId: id,
+              nearestPointIndex: updates.nearestPointIndex,
+              distanceFromStart: distanceFromStart
+            })
           }
           
           return updatedWaypoint

--- a/src/store/routeStore.ts
+++ b/src/store/routeStore.ts
@@ -222,10 +222,23 @@ export const useRouteStore = create<RouteState>((set, get) => ({
   },
   
   updateWaypoint: (id, updates) => {
+    const state = get()
+    
     set(state => ({
-      waypoints: state.waypoints.map(w => 
-        w.id === id ? { ...w, ...updates } : w
-      )
+      waypoints: state.waypoints.map(w => {
+        if (w.id === id) {
+          const updatedWaypoint = { ...w, ...updates }
+          
+          // nearestPointIndexが更新された場合、距離を再計算
+          if (updates.nearestPointIndex !== undefined && state.route.points.length >= 2) {
+            const distanceFromStart = calculateDistanceToIndex(state.route.points, updates.nearestPointIndex)
+            updatedWaypoint.distanceFromStart = distanceFromStart
+          }
+          
+          return updatedWaypoint
+        }
+        return w
+      })
     }))
   },
   

--- a/src/store/routeStore.ts
+++ b/src/store/routeStore.ts
@@ -229,6 +229,11 @@ export const useRouteStore = create<RouteState>((set, get) => ({
   
   updateWaypointDistances: () => {
     const state = get()
+    console.log('updateWaypointDistances called', {
+      routePoints: state.route.points.length,
+      waypoints: state.waypoints
+    })
+    
     const updatedWaypoints = state.waypoints.map(waypoint => {
       // nearestPointIndexがない場合は、最も近いポイントを探す
       let nearestIndex = waypoint.nearestPointIndex
@@ -240,15 +245,18 @@ export const useRouteStore = create<RouteState>((set, get) => ({
           state.route.points
         )
         nearestIndex = closestPoint.nearestPointIndex
+        console.log('Found nearest index for waypoint', waypoint.name, nearestIndex)
       }
       
       if (nearestIndex !== undefined) {
         const distanceFromStart = calculateDistanceToIndex(state.route.points, nearestIndex)
+        console.log('Calculated distance for waypoint', waypoint.name, distanceFromStart)
         return { ...waypoint, nearestPointIndex: nearestIndex, distanceFromStart }
       }
       return waypoint
     })
     
+    console.log('Updated waypoints:', updatedWaypoints)
     set({ waypoints: updatedWaypoints })
   }
 }))

--- a/src/store/routeStore.ts
+++ b/src/store/routeStore.ts
@@ -235,6 +235,14 @@ export const useRouteStore = create<RouteState>((set, get) => ({
     })
     
     const updatedWaypoints = state.waypoints.map(waypoint => {
+      console.log('Processing waypoint:', {
+        name: waypoint.name,
+        nearestPointIndex: waypoint.nearestPointIndex,
+        lat: waypoint.lat,
+        lng: waypoint.lng,
+        currentDistanceFromStart: waypoint.distanceFromStart
+      })
+      
       // nearestPointIndexがない場合は、最も近いポイントを探す
       let nearestIndex = waypoint.nearestPointIndex
       if (nearestIndex === undefined && state.route.points.length >= 2) {
@@ -250,7 +258,7 @@ export const useRouteStore = create<RouteState>((set, get) => ({
       
       if (nearestIndex !== undefined) {
         const distanceFromStart = calculateDistanceToIndex(state.route.points, nearestIndex)
-        console.log('Calculated distance for waypoint', waypoint.name, distanceFromStart)
+        console.log('Calculated distance for waypoint', waypoint.name, 'index:', nearestIndex, 'distance:', distanceFromStart)
         return { ...waypoint, nearestPointIndex: nearestIndex, distanceFromStart }
       }
       return waypoint

--- a/src/store/routeStore.ts
+++ b/src/store/routeStore.ts
@@ -186,7 +186,6 @@ export const useRouteStore = create<RouteState>((set, get) => ({
   
   addWaypoint: (waypoint) => {
     const state = get()
-    console.log('addWaypoint called with:', waypoint)
     
     // nearestPointIndexが設定されている場合、始点からの距離を計算
     const distanceFromStart = waypoint.nearestPointIndex !== undefined
@@ -198,7 +197,6 @@ export const useRouteStore = create<RouteState>((set, get) => ({
       id: generateId(),
       distanceFromStart
     }
-    console.log('Created new waypoint:', newWaypoint)
     
     set(state => ({
       waypoints: [...state.waypoints, newWaypoint]
@@ -233,19 +231,8 @@ export const useRouteStore = create<RouteState>((set, get) => ({
   
   updateWaypointDistances: () => {
     const state = get()
-    console.log('updateWaypointDistances called', {
-      routePoints: state.route.points.length,
-      waypoints: state.waypoints
-    })
     
     const updatedWaypoints = state.waypoints.map(waypoint => {
-      console.log('Processing waypoint:', {
-        name: waypoint.name,
-        nearestPointIndex: waypoint.nearestPointIndex,
-        lat: waypoint.lat,
-        lng: waypoint.lng,
-        currentDistanceFromStart: waypoint.distanceFromStart
-      })
       
       // nearestPointIndexがない場合は、最も近いポイントを探す
       let nearestIndex = waypoint.nearestPointIndex
@@ -257,18 +244,18 @@ export const useRouteStore = create<RouteState>((set, get) => ({
           state.route.points
         )
         nearestIndex = closestPoint.nearestPointIndex
-        console.log('Found nearest index for waypoint', waypoint.name, nearestIndex)
+        
       }
       
       if (nearestIndex !== undefined) {
         const distanceFromStart = calculateDistanceToIndex(state.route.points, nearestIndex)
-        console.log('Calculated distance for waypoint', waypoint.name, 'index:', nearestIndex, 'distance:', distanceFromStart)
+        
         return { ...waypoint, nearestPointIndex: nearestIndex, distanceFromStart }
       }
       return waypoint
     })
     
-    console.log('Updated waypoints:', updatedWaypoints)
+    
     set({ waypoints: updatedWaypoints })
   }
 }))

--- a/src/store/routeStore.ts
+++ b/src/store/routeStore.ts
@@ -186,6 +186,8 @@ export const useRouteStore = create<RouteState>((set, get) => ({
   
   addWaypoint: (waypoint) => {
     const state = get()
+    console.log('addWaypoint called with:', waypoint)
+    
     // nearestPointIndexが設定されている場合、始点からの距離を計算
     const distanceFromStart = waypoint.nearestPointIndex !== undefined
       ? calculateDistanceToIndex(state.route.points, waypoint.nearestPointIndex)
@@ -196,6 +198,8 @@ export const useRouteStore = create<RouteState>((set, get) => ({
       id: generateId(),
       distanceFromStart
     }
+    console.log('Created new waypoint:', newWaypoint)
+    
     set(state => ({
       waypoints: [...state.waypoints, newWaypoint]
     }))

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -10,7 +10,7 @@ interface UIState {
   selectedWaypointId: string | null
   hoveredWaypointId: string | null
   waypointDialogOpen: boolean
-  pendingWaypoint: { lat: number; lng: number } | null
+  pendingWaypoint: { lat: number; lng: number; nearestPointIndex?: number } | null
   selectionBox: { start: { x: number; y: number }; end: { x: number; y: number } } | null
   mapStyle: MapStyleId
   setEditMode: (mode: EditMode) => void
@@ -19,7 +19,7 @@ interface UIState {
   setSelectedWaypoint: (id: string | null) => void
   setHoveredWaypoint: (id: string | null) => void
   setWaypointDialogOpen: (open: boolean) => void
-  setPendingWaypoint: (waypoint: { lat: number; lng: number } | null) => void
+  setPendingWaypoint: (waypoint: { lat: number; lng: number; nearestPointIndex?: number } | null) => void
   setSelectionBox: (box: { start: { x: number; y: number }; end: { x: number; y: number } } | null) => void
   setMapStyle: (style: MapStyleId) => void
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,8 @@ export interface Waypoint {
   type: WaypointType
   // ルート上の最も近いポイントのインデックス（移動時に使用）
   nearestPointIndex?: number
+  // ルート始点からの距離（km）
+  distanceFromStart?: number
 }
 
 export type EditMode = 'view' | 'create' | 'edit' | 'delete' | 'delete-range' | 'waypoint'

--- a/src/utils/__tests__/geo.test.ts
+++ b/src/utils/__tests__/geo.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { calculateDistance, calculateDistanceToIndex, findClosestPointOnRoute } from '../geo'
+import { RoutePoint } from '@/types'
+
+describe('geo utilities', () => {
+  describe('calculateDistance', () => {
+    it('空の配列の場合は0を返す', () => {
+      expect(calculateDistance([])).toBe(0)
+    })
+
+    it('1点のみの場合は0を返す', () => {
+      const points: RoutePoint[] = [
+        { id: '1', lat: 35.681236, lng: 139.767125 }
+      ]
+      expect(calculateDistance(points)).toBe(0)
+    })
+
+    it('2点間の距離を正しく計算する', () => {
+      const points: RoutePoint[] = [
+        { id: '1', lat: 35.681236, lng: 139.767125 }, // 東京駅
+        { id: '2', lat: 35.658034, lng: 139.701637 }  // 渋谷駅
+      ]
+      const distance = calculateDistance(points)
+      // 約7.5km
+      expect(distance).toBeGreaterThan(7000)
+      expect(distance).toBeLessThan(8000)
+    })
+
+    it('複数点の合計距離を正しく計算する', () => {
+      const points: RoutePoint[] = [
+        { id: '1', lat: 35.681236, lng: 139.767125 }, // 東京駅
+        { id: '2', lat: 35.658034, lng: 139.701637 }, // 渋谷駅
+        { id: '3', lat: 35.628471, lng: 139.738993 }  // 品川駅
+      ]
+      const distance = calculateDistance(points)
+      // 約12km
+      expect(distance).toBeGreaterThan(11000)
+      expect(distance).toBeLessThan(13000)
+    })
+  })
+
+  describe('calculateDistanceToIndex', () => {
+    const points: RoutePoint[] = [
+      { id: '1', lat: 35.681236, lng: 139.767125 }, // 東京駅
+      { id: '2', lat: 35.658034, lng: 139.701637 }, // 渋谷駅
+      { id: '3', lat: 35.628471, lng: 139.738993 }, // 品川駅
+      { id: '4', lat: 35.630152, lng: 139.740311 }  // 近い点
+    ]
+
+    it('インデックス0の場合は0を返す', () => {
+      expect(calculateDistanceToIndex(points, 0)).toBe(0)
+    })
+
+    it('負のインデックスの場合は0を返す', () => {
+      expect(calculateDistanceToIndex(points, -1)).toBe(0)
+    })
+
+    it('ポイントが2つ未満の場合は0を返す', () => {
+      expect(calculateDistanceToIndex([points[0]], 1)).toBe(0)
+      expect(calculateDistanceToIndex([], 0)).toBe(0)
+    })
+
+    it('インデックス1までの距離を正しく計算する', () => {
+      const distance = calculateDistanceToIndex(points, 1)
+      // 東京駅から渋谷駅まで約7.5km
+      expect(distance).toBeGreaterThan(7)
+      expect(distance).toBeLessThan(8)
+    })
+
+    it('インデックス2までの距離を正しく計算する', () => {
+      const distance = calculateDistanceToIndex(points, 2)
+      // 東京駅から渋谷駅経由で品川駅まで約12km
+      expect(distance).toBeGreaterThan(11)
+      expect(distance).toBeLessThan(13)
+    })
+
+    it('範囲外のインデックスの場合は最後のポイントまでの距離を返す', () => {
+      const distance = calculateDistanceToIndex(points, 10)
+      const totalDistance = calculateDistance(points)
+      expect(distance).toBe(totalDistance / 1000) // kmに変換
+    })
+  })
+
+  describe('findClosestPointOnRoute', () => {
+    const points: RoutePoint[] = [
+      { id: '1', lat: 35.681236, lng: 139.767125 }, // 東京駅
+      { id: '2', lat: 35.658034, lng: 139.701637 }, // 渋谷駅
+      { id: '3', lat: 35.628471, lng: 139.738993 }  // 品川駅
+    ]
+
+    it('ポイントが2つ未満の場合はクリック位置を返す', () => {
+      const result = findClosestPointOnRoute(35.7, 139.7, [])
+      expect(result.lat).toBe(35.7)
+      expect(result.lng).toBe(139.7)
+      expect(result.nearestPointIndex).toBe(0)
+
+      const result2 = findClosestPointOnRoute(35.7, 139.7, [points[0]])
+      expect(result2.lat).toBe(35.7)
+      expect(result2.lng).toBe(139.7)
+      expect(result2.nearestPointIndex).toBe(0)
+    })
+
+    it('ルート上の最も近い点を正しく計算する', () => {
+      // 東京駅と渋谷駅の中間付近の点
+      const result = findClosestPointOnRoute(35.670000, 139.734000, points)
+      
+      // 結果は東京駅と渋谷駅の間のどこかであるべき
+      expect(result.lat).toBeGreaterThan(35.658)
+      expect(result.lat).toBeLessThan(35.682)
+      expect(result.lng).toBeGreaterThan(139.701)
+      expect(result.lng).toBeLessThan(139.768)
+      expect(result.nearestPointIndex).toBe(0) // 最初のセグメント
+    })
+
+    it('セグメントインデックスを正しく特定する', () => {
+      // 渋谷駅と品川駅の中間付近の点
+      const result = findClosestPointOnRoute(35.643000, 139.720000, points)
+      
+      // 結果は渋谷駅と品川駅の間のどこかであるべき
+      expect(result.lat).toBeGreaterThan(35.628)
+      expect(result.lat).toBeLessThan(35.659)
+      expect(result.nearestPointIndex).toBe(1) // 2番目のセグメント
+    })
+  })
+})

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -92,6 +92,8 @@ export function findClosestPointOnRoute(
   const snappedCoords = snapped.geometry.coordinates
   
   // Check which segment contains the snapped point
+  const segmentDistances: Array<{index: number, distance: number}> = []
+  
   for (let i = 0; i < points.length - 1; i++) {
     const segment = turf.lineString([
       [points[i].lng, points[i].lat],
@@ -106,14 +108,16 @@ export function findClosestPointOnRoute(
       'degrees'
     )
     
+    segmentDistances.push({index: i, distance: distanceToSegment})
     
     // 最小距離のセグメントを記録
     if (distanceToSegment < minDistance) {
       minDistance = distanceToSegment
       nearestPointIndex = i
-      
     }
   }
+  
+  console.log('Segment distances:', segmentDistances)
   
   console.log('findClosestPointOnRoute:', {
     clickLat,

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -73,11 +73,6 @@ export function findClosestPointOnRoute(
   clickLng: number,
   points: RoutePoint[]
 ): { lat: number; lng: number; nearestPointIndex: number } {
-  console.log('findClosestPointOnRoute called:', {
-    clickLat,
-    clickLng,
-    pointsLength: points.length
-  })
   
   if (points.length < 2) {
     return { lat: clickLat, lng: clickLng, nearestPointIndex: 0 }
@@ -90,7 +85,6 @@ export function findClosestPointOnRoute(
   
   // Find the nearest point on the line
   const snapped = turf.pointOnLine(line, clickPoint)
-  console.log('Snapped point:', snapped.geometry.coordinates)
   
   // Find which segment the snapped point is on
   let nearestPointIndex = 0
@@ -112,17 +106,15 @@ export function findClosestPointOnRoute(
       'degrees'
     )
     
-    console.log(`Segment ${i}: distance = ${distanceToSegment}`)
     
     // 最小距離のセグメントを記録
     if (distanceToSegment < minDistance) {
       minDistance = distanceToSegment
       nearestPointIndex = i
-      console.log(`New minimum found at segment ${i} with distance ${distanceToSegment}`)
+      
     }
   }
   
-  console.log('Final nearestPointIndex:', nearestPointIndex, 'with min distance:', minDistance)
   
   return {
     lat: snappedCoords[1],
@@ -141,23 +133,15 @@ export function calculateDistanceToIndex(
   points: RoutePoint[],
   targetIndex: number
 ): number {
-  console.log('calculateDistanceToIndex called with:', {
-    pointsLength: points.length,
-    targetIndex: targetIndex
-  })
   
   if (points.length < 2 || targetIndex < 0) {
-    console.log('Returning 0 because:', {
-      pointsLength: points.length,
-      targetIndex: targetIndex,
-      condition: 'points.length < 2 || targetIndex < 0'
-    })
+    
     return 0
   }
   
   // インデックス0の場合も距離は0
   if (targetIndex === 0) {
-    console.log('Returning 0 for index 0 (start point)')
+    
     return 0
   }
   
@@ -166,17 +150,10 @@ export function calculateDistanceToIndex(
   
   // Create sub-route from start to target index
   const subRoute = points.slice(0, limitedIndex + 1)
-  console.log('Calculating distance for sub-route:', {
-    subRouteLength: subRoute.length,
-    limitedIndex: limitedIndex
-  })
   
   // Convert to meters then to kilometers
   const distanceMeters = calculateDistance(subRoute)
   const distanceKm = distanceMeters / 1000
-  console.log('Distance calculated:', {
-    distanceMeters: distanceMeters,
-    distanceKm: distanceKm
-  })
+  
   return distanceKm
 }

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -116,3 +116,26 @@ export function findClosestPointOnRoute(
     nearestPointIndex
   }
 }
+
+/**
+ * Calculate distance from route start to a specific point index
+ * @param points Route points array
+ * @param targetIndex Index to calculate distance to
+ * @returns Distance in kilometers
+ */
+export function calculateDistanceToIndex(
+  points: RoutePoint[],
+  targetIndex: number
+): number {
+  if (points.length < 2 || targetIndex <= 0) return 0
+  
+  // Limit targetIndex to valid range
+  const limitedIndex = Math.min(targetIndex, points.length - 1)
+  
+  // Create sub-route from start to target index
+  const subRoute = points.slice(0, limitedIndex + 1)
+  
+  // Convert to meters then to kilometers
+  const distanceMeters = calculateDistance(subRoute)
+  return distanceMeters / 1000
+}

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -115,6 +115,14 @@ export function findClosestPointOnRoute(
     }
   }
   
+  console.log('findClosestPointOnRoute:', {
+    clickLat,
+    clickLng,
+    snappedLat: snappedCoords[1],
+    snappedLng: snappedCoords[0],
+    nearestPointIndex,
+    minDistance
+  })
   
   return {
     lat: snappedCoords[1],
@@ -133,15 +141,17 @@ export function calculateDistanceToIndex(
   points: RoutePoint[],
   targetIndex: number
 ): number {
+  console.log('calculateDistanceToIndex:', {
+    pointsLength: points.length,
+    targetIndex: targetIndex
+  })
   
   if (points.length < 2 || targetIndex < 0) {
-    
     return 0
   }
   
   // インデックス0の場合も距離は0
   if (targetIndex === 0) {
-    
     return 0
   }
   
@@ -154,6 +164,13 @@ export function calculateDistanceToIndex(
   // Convert to meters then to kilometers
   const distanceMeters = calculateDistance(subRoute)
   const distanceKm = distanceMeters / 1000
+  
+  console.log('calculateDistanceToIndex result:', {
+    limitedIndex,
+    subRouteLength: subRoute.length,
+    distanceMeters,
+    distanceKm
+  })
   
   return distanceKm
 }

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -127,15 +127,42 @@ export function calculateDistanceToIndex(
   points: RoutePoint[],
   targetIndex: number
 ): number {
-  if (points.length < 2 || targetIndex <= 0) return 0
+  console.log('calculateDistanceToIndex called with:', {
+    pointsLength: points.length,
+    targetIndex: targetIndex
+  })
+  
+  if (points.length < 2 || targetIndex < 0) {
+    console.log('Returning 0 because:', {
+      pointsLength: points.length,
+      targetIndex: targetIndex,
+      condition: 'points.length < 2 || targetIndex < 0'
+    })
+    return 0
+  }
+  
+  // インデックス0の場合も距離は0
+  if (targetIndex === 0) {
+    console.log('Returning 0 for index 0 (start point)')
+    return 0
+  }
   
   // Limit targetIndex to valid range
   const limitedIndex = Math.min(targetIndex, points.length - 1)
   
   // Create sub-route from start to target index
   const subRoute = points.slice(0, limitedIndex + 1)
+  console.log('Calculating distance for sub-route:', {
+    subRouteLength: subRoute.length,
+    limitedIndex: limitedIndex
+  })
   
   // Convert to meters then to kilometers
   const distanceMeters = calculateDistance(subRoute)
-  return distanceMeters / 1000
+  const distanceKm = distanceMeters / 1000
+  console.log('Distance calculated:', {
+    distanceMeters: distanceMeters,
+    distanceKm: distanceKm
+  })
+  return distanceKm
 }

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -94,6 +94,7 @@ export function findClosestPointOnRoute(
   
   // Find which segment the snapped point is on
   let nearestPointIndex = 0
+  let minDistance = Infinity
   const snappedCoords = snapped.geometry.coordinates
   
   // Check which segment contains the snapped point
@@ -113,14 +114,15 @@ export function findClosestPointOnRoute(
     
     console.log(`Segment ${i}: distance = ${distanceToSegment}`)
     
-    if (distanceToSegment < 0.0000001) { // Very small threshold for floating point comparison
+    // 最小距離のセグメントを記録
+    if (distanceToSegment < minDistance) {
+      minDistance = distanceToSegment
       nearestPointIndex = i
-      console.log(`Found nearest segment: ${i}`)
-      break
+      console.log(`New minimum found at segment ${i} with distance ${distanceToSegment}`)
     }
   }
   
-  console.log('Final nearestPointIndex:', nearestPointIndex)
+  console.log('Final nearestPointIndex:', nearestPointIndex, 'with min distance:', minDistance)
   
   return {
     lat: snappedCoords[1],

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -73,6 +73,12 @@ export function findClosestPointOnRoute(
   clickLng: number,
   points: RoutePoint[]
 ): { lat: number; lng: number; nearestPointIndex: number } {
+  console.log('findClosestPointOnRoute called:', {
+    clickLat,
+    clickLng,
+    pointsLength: points.length
+  })
+  
   if (points.length < 2) {
     return { lat: clickLat, lng: clickLng, nearestPointIndex: 0 }
   }
@@ -84,6 +90,7 @@ export function findClosestPointOnRoute(
   
   // Find the nearest point on the line
   const snapped = turf.pointOnLine(line, clickPoint)
+  console.log('Snapped point:', snapped.geometry.coordinates)
   
   // Find which segment the snapped point is on
   let nearestPointIndex = 0
@@ -104,11 +111,16 @@ export function findClosestPointOnRoute(
       'degrees'
     )
     
+    console.log(`Segment ${i}: distance = ${distanceToSegment}`)
+    
     if (distanceToSegment < 0.0000001) { // Very small threshold for floating point comparison
       nearestPointIndex = i
+      console.log(`Found nearest segment: ${i}`)
       break
     }
   }
+  
+  console.log('Final nearestPointIndex:', nearestPointIndex)
   
   return {
     lat: snappedCoords[1],


### PR DESCRIPTION
## 概要
- Waypointに開始地点からの距離情報を追加しました
- Waypointのポップアップとダイアログで距離を表示
- ルート変更時に自動で距離を再計算

## 実装内容
- `Waypoint`型に`distanceFromStart`プロパティを追加
- `calculateDistanceToIndex`関数を新規作成（既存の`calculateDistance`を再利用）
- `routeStore`に`updateWaypointDistances`関数を追加
- WaypointマーカーのPopupとWaypointDialogに距離表示を追加
- ルート変更時（addPoint, insertPoint, updatePoint, deletePoint, deleteMultiplePoints）に距離を自動更新

## テスト計画
- [x] 新規Waypointを作成して距離が表示されることを確認
- [x] ルートポイントを追加・削除してWaypointの距離が更新されることを確認
- [x] Waypointをドラッグして移動した際に距離が更新されることを確認
- [x] calculateDistanceToIndex関数の単体テストを追加
- [x] 型チェックとlintが通ることを確認

Close #32

🤖 Generated with [Claude Code](https://claude.ai/code)