### PR TITLE
refactor: 履歴管理ロジックをRouteHistoryManagerに分離 (Phase 1)

### DIFF
--- a/src/domain/RouteHistoryManager.ts
+++ b/src/domain/RouteHistoryManager.ts
@@ -1,0 +1,42 @@
+import { Route, Waypoint } from '@/types'
+
+export interface HistoryState {
+  route: Route
+  waypoints: Waypoint[]
+}
+
+export class RouteHistoryManager {
+  static createSnapshot(route: Route, waypoints: Waypoint[]): HistoryState {
+    // 深いコピーを作成して独立性を保証
+    return {
+      route: {
+        points: route.points.map(p => ({ ...p })),
+        distance: route.distance
+      },
+      waypoints: waypoints.map(w => ({ ...w }))
+    }
+  }
+  
+  static canUndo(historyIndex: number): boolean {
+    return historyIndex > 0
+  }
+  
+  static canRedo(historyIndex: number, historyLength: number): boolean {
+    return historyIndex < historyLength - 1
+  }
+  
+  static addToHistory(
+    history: HistoryState[], 
+    currentIndex: number, 
+    newState: HistoryState
+  ): { history: HistoryState[], newIndex: number } {
+    // 現在の位置までの履歴を保持し、未来の履歴は削除
+    const newHistory = history.slice(0, currentIndex + 1)
+    newHistory.push(newState)
+    
+    return {
+      history: newHistory,
+      newIndex: newHistory.length - 1
+    }
+  }
+}

--- a/src/domain/__tests__/RouteHistoryManager.test.ts
+++ b/src/domain/__tests__/RouteHistoryManager.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { RouteHistoryManager } from '../RouteHistoryManager'
+import { Route, Waypoint } from '@/types'
+
+describe('RouteHistoryManager', () => {
+  const mockRoute: Route = {
+    points: [
+      { id: '1', lat: 35.6762, lng: 139.6503 },
+      { id: '2', lat: 35.6795, lng: 139.6475 }
+    ],
+    distance: 1000
+  }
+  
+  const mockWaypoints: Waypoint[] = [
+    {
+      id: 'w1',
+      lat: 35.6770,
+      lng: 139.6490,
+      name: 'Waypoint 1',
+      description: 'Test waypoint',
+      nearestPointIndex: 0,
+      distanceFromStart: 500
+    }
+  ]
+
+  describe('createSnapshot', () => {
+    it('should create a snapshot with route and waypoints', () => {
+      const snapshot = RouteHistoryManager.createSnapshot(mockRoute, mockWaypoints)
+      
+      expect(snapshot).toEqual({
+        route: mockRoute,
+        waypoints: mockWaypoints
+      })
+    })
+    
+    it('should create independent copies of route and waypoints', () => {
+      const snapshot = RouteHistoryManager.createSnapshot(mockRoute, mockWaypoints)
+      
+      // 元のオブジェクトを変更
+      mockRoute.distance = 2000
+      mockWaypoints[0].name = 'Modified'
+      
+      // スナップショットは影響を受けない
+      expect(snapshot.route.distance).toBe(1000)
+      expect(snapshot.waypoints[0].name).toBe('Waypoint 1')
+    })
+  })
+  
+  describe('canUndo', () => {
+    it('should return false when historyIndex is 0', () => {
+      expect(RouteHistoryManager.canUndo(0)).toBe(false)
+    })
+    
+    it('should return true when historyIndex is greater than 0', () => {
+      expect(RouteHistoryManager.canUndo(1)).toBe(true)
+      expect(RouteHistoryManager.canUndo(5)).toBe(true)
+    })
+  })
+  
+  describe('canRedo', () => {
+    it('should return false when at the latest state', () => {
+      expect(RouteHistoryManager.canRedo(2, 3)).toBe(false) // index 2, length 3
+    })
+    
+    it('should return true when not at the latest state', () => {
+      expect(RouteHistoryManager.canRedo(0, 3)).toBe(true) // index 0, length 3
+      expect(RouteHistoryManager.canRedo(1, 3)).toBe(true) // index 1, length 3
+    })
+  })
+  
+  describe('addToHistory', () => {
+    it('should add new state and update index when at the latest state', () => {
+      const history = [
+        { route: mockRoute, waypoints: [] },
+        { route: mockRoute, waypoints: mockWaypoints }
+      ]
+      const currentIndex = 1
+      const newState = { route: mockRoute, waypoints: [...mockWaypoints, ...mockWaypoints] }
+      
+      const result = RouteHistoryManager.addToHistory(history, currentIndex, newState)
+      
+      expect(result.history).toHaveLength(3)
+      expect(result.history[2]).toEqual(newState)
+      expect(result.newIndex).toBe(2)
+    })
+    
+    it('should truncate future history when adding from middle', () => {
+      const history = [
+        { route: mockRoute, waypoints: [] },
+        { route: mockRoute, waypoints: mockWaypoints },
+        { route: mockRoute, waypoints: [...mockWaypoints, ...mockWaypoints] }
+      ]
+      const currentIndex = 1 // 中間の状態
+      const newState = { route: mockRoute, waypoints: [] }
+      
+      const result = RouteHistoryManager.addToHistory(history, currentIndex, newState)
+      
+      expect(result.history).toHaveLength(3) // 0, 1, new
+      expect(result.history[2]).toEqual(newState)
+      expect(result.newIndex).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
## 概要
issue #42 のPhase 1として、履歴管理ロジックをStoreから分離し、専用のRouteHistoryManagerクラスに移行しました。

## 変更内容

### TDDアプローチの実践
t_wadaのTDD原則に従い、以下の手順で実装：
1. **Red**: RouteHistoryManagerのテストを先に作成
2. **Green**: テストを通すための最小限の実装
3. **Refactor**: routeStoreを更新して新しいクラスを使用

### 新規作成
- `src/domain/RouteHistoryManager.ts`: 履歴管理専用クラス
- `src/domain/__tests__/RouteHistoryManager.test.ts`: 包括的なテストスイート

### RouteHistoryManagerの責務
- `createSnapshot()`: 状態の深いコピーを作成（独立性を保証）
- `canUndo()` / `canRedo()`: 操作可否の判定ロジック
- `addToHistory()`: 履歴への追加と未来の履歴の削除

### リファクタリング内容
- routeStore内のすべての履歴操作をRouteHistoryManagerに委譲
- 履歴管理のロジックがStoreから完全に分離
- コードの見通しが改善され、テストが容易に

## テスト結果
- ✅ 全65テストが通過
- ✅ TypeScriptコンパイル成功
- ✅ ESLint警告なし

## 次のステップ（Phase 2-4）
- Phase 2: ファクトリー関数の分離（Waypoint、RoutePoint作成）
- Phase 3: ドメインロジックの分離（距離計算など）
- Phase 4: Storeの簡素化（純粋な状態管理に特化）

## 関連
- Relates to #42

🤖 Generated with [Claude Code](https://claude.ai/code)