### PR TITLE
Phase 3: ルートとWaypoint距離計算ロジックのドメインレイヤー分離

### DIFF
--- a/src/domain/__tests__/route-calculator.test.ts
+++ b/src/domain/__tests__/route-calculator.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { RouteCalculator } from '../route-calculator'
+import { RoutePoint, Route } from '@/types'
+
+describe('RouteCalculator', () => {
+  const mockPoints: RoutePoint[] = [
+    { id: '1', lat: 35.6762, lng: 139.6503 }, // Tokyo Tower
+    { id: '2', lat: 35.6795, lng: 139.6475 }, // ~500m north
+    { id: '3', lat: 35.6820, lng: 139.6450 }  // ~750m further
+  ]
+  
+  describe('calculateRouteDistance', () => {
+    it('should return 0 for empty route', () => {
+      const distance = RouteCalculator.calculateRouteDistance([])
+      expect(distance).toBe(0)
+    })
+    
+    it('should return 0 for single point', () => {
+      const distance = RouteCalculator.calculateRouteDistance([mockPoints[0]])
+      expect(distance).toBe(0)
+    })
+    
+    it('should calculate distance for multiple points', () => {
+      const distance = RouteCalculator.calculateRouteDistance(mockPoints)
+      // Approximate distance should be around 800 meters
+      expect(distance).toBeGreaterThan(700)
+      expect(distance).toBeLessThan(900)
+    })
+    
+    it('should return consistent results', () => {
+      const distance1 = RouteCalculator.calculateRouteDistance(mockPoints)
+      const distance2 = RouteCalculator.calculateRouteDistance(mockPoints)
+      expect(distance1).toBe(distance2)
+    })
+  })
+  
+  describe('createRoute', () => {
+    it('should create route with calculated distance', () => {
+      const route = RouteCalculator.createRoute(mockPoints)
+      expect(route.points).toEqual(mockPoints)
+      expect(route.distance).toBeGreaterThan(0)
+    })
+    
+    it('should handle empty points', () => {
+      const route = RouteCalculator.createRoute([])
+      expect(route.points).toEqual([])
+      expect(route.distance).toBe(0)
+    })
+  })
+  
+  describe('updateRouteDistance', () => {
+    it('should update existing route with new distance', () => {
+      const route: Route = { points: mockPoints, distance: 0 }
+      const updatedRoute = RouteCalculator.updateRouteDistance(route)
+      
+      expect(updatedRoute.points).toEqual(mockPoints)
+      expect(updatedRoute.distance).toBeGreaterThan(0)
+      expect(updatedRoute).not.toBe(route) // Should return new object
+    })
+    
+    it('should preserve route points', () => {
+      const route: Route = { points: mockPoints, distance: 999 }
+      const updatedRoute = RouteCalculator.updateRouteDistance(route)
+      
+      expect(updatedRoute.points).toBe(route.points) // Same reference
+    })
+  })
+})

--- a/src/domain/__tests__/waypoint-calculator.test.ts
+++ b/src/domain/__tests__/waypoint-calculator.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { WaypointCalculator } from '../waypoint-calculator'
+import { RoutePoint, Waypoint } from '@/types'
+
+describe('WaypointCalculator', () => {
+  const mockRoutePoints: RoutePoint[] = [
+    { id: '1', lat: 35.6762, lng: 139.6503 },
+    { id: '2', lat: 35.6795, lng: 139.6475 },
+    { id: '3', lat: 35.6820, lng: 139.6450 }
+  ]
+  
+  const mockWaypoint: Waypoint = {
+    id: 'w1',
+    lat: 35.6780,
+    lng: 139.6480,
+    name: 'Test Waypoint',
+    description: 'Test description',
+    nearestPointIndex: 0,
+    distanceFromStart: 0
+  }
+  
+  describe('calculateDistanceToWaypoint', () => {
+    it('should return 0 for empty route', () => {
+      const distance = WaypointCalculator.calculateDistanceToWaypoint(mockWaypoint, [])
+      expect(distance).toBe(0)
+    })
+    
+    it('should return 0 for single point route', () => {
+      const distance = WaypointCalculator.calculateDistanceToWaypoint(
+        mockWaypoint, 
+        [mockRoutePoints[0]]
+      )
+      expect(distance).toBe(0)
+    })
+    
+    it('should calculate distance for waypoint on route', () => {
+      const distance = WaypointCalculator.calculateDistanceToWaypoint(
+        mockWaypoint,
+        mockRoutePoints
+      )
+      expect(distance).toBeGreaterThan(0)
+      expect(distance).toBeLessThan(1) // Less than 1km
+    })
+    
+    it('should handle waypoint without nearestPointIndex', () => {
+      const waypointWithoutIndex = { ...mockWaypoint, nearestPointIndex: undefined }
+      const distance = WaypointCalculator.calculateDistanceToWaypoint(
+        waypointWithoutIndex as Waypoint,
+        mockRoutePoints
+      )
+      expect(distance).toBe(0)
+    })
+  })
+  
+  describe('updateWaypointDistance', () => {
+    it('should update waypoint with calculated distance', () => {
+      const updatedWaypoint = WaypointCalculator.updateWaypointDistance(
+        mockWaypoint,
+        mockRoutePoints
+      )
+      
+      expect(updatedWaypoint).not.toBe(mockWaypoint) // New object
+      expect(updatedWaypoint.distanceFromStart).toBeGreaterThan(0)
+      expect(updatedWaypoint.id).toBe(mockWaypoint.id)
+      expect(updatedWaypoint.name).toBe(mockWaypoint.name)
+    })
+  })
+  
+  describe('updateAllWaypointDistances', () => {
+    it('should update all waypoints with calculated distances', () => {
+      const waypoints: Waypoint[] = [
+        { ...mockWaypoint, id: 'w1', nearestPointIndex: 0 },
+        { ...mockWaypoint, id: 'w2', nearestPointIndex: 1, lat: 35.6800 }
+      ]
+      
+      const updatedWaypoints = WaypointCalculator.updateAllWaypointDistances(
+        waypoints,
+        mockRoutePoints
+      )
+      
+      expect(updatedWaypoints).toHaveLength(2)
+      expect(updatedWaypoints[0].distanceFromStart).toBeGreaterThan(0)
+      expect(updatedWaypoints[1].distanceFromStart).toBeGreaterThan(
+        updatedWaypoints[0].distanceFromStart
+      )
+    })
+    
+    it('should handle empty waypoints array', () => {
+      const updatedWaypoints = WaypointCalculator.updateAllWaypointDistances(
+        [],
+        mockRoutePoints
+      )
+      expect(updatedWaypoints).toEqual([])
+    })
+  })
+})

--- a/src/domain/route-calculator.ts
+++ b/src/domain/route-calculator.ts
@@ -1,0 +1,40 @@
+import { RoutePoint, Route } from '@/types'
+import { calculateDistance } from '@/utils/geo'
+
+/**
+ * ルート計算に関するドメインロジック
+ */
+export class RouteCalculator {
+  /**
+   * ルートポイント間の総距離を計算する
+   * @param points ルートポイントの配列
+   * @returns 総距離（メートル）
+   */
+  static calculateRouteDistance(points: RoutePoint[]): number {
+    return calculateDistance(points)
+  }
+  
+  /**
+   * ポイント配列から新しいRouteオブジェクトを作成する
+   * @param points ルートポイントの配列
+   * @returns 距離が計算されたRouteオブジェクト
+   */
+  static createRoute(points: RoutePoint[]): Route {
+    return {
+      points,
+      distance: this.calculateRouteDistance(points)
+    }
+  }
+  
+  /**
+   * 既存のRouteの距離を再計算して新しいRouteオブジェクトを返す
+   * @param route 既存のRoute
+   * @returns 距離が更新された新しいRouteオブジェクト
+   */
+  static updateRouteDistance(route: Route): Route {
+    return {
+      ...route,
+      distance: this.calculateRouteDistance(route.points)
+    }
+  }
+}

--- a/src/domain/waypoint-calculator.ts
+++ b/src/domain/waypoint-calculator.ts
@@ -1,0 +1,49 @@
+import { Waypoint, RoutePoint } from '@/types'
+import { calculateDistanceToWaypoint, calculateAllWaypointDistances } from '@/utils/geo'
+
+/**
+ * Waypoint関連の計算ロジック
+ */
+export class WaypointCalculator {
+  /**
+   * ルート開始地点からWaypointまでの距離を計算する
+   * @param waypoint 対象のWaypoint
+   * @param routePoints ルートポイントの配列
+   * @returns 距離（キロメートル）
+   */
+  static calculateDistanceToWaypoint(
+    waypoint: Waypoint,
+    routePoints: RoutePoint[]
+  ): number {
+    return calculateDistanceToWaypoint(waypoint, routePoints)
+  }
+  
+  /**
+   * Waypointの距離を更新して新しいオブジェクトを返す
+   * @param waypoint 対象のWaypoint
+   * @param routePoints ルートポイントの配列
+   * @returns 距離が更新された新しいWaypointオブジェクト
+   */
+  static updateWaypointDistance(
+    waypoint: Waypoint,
+    routePoints: RoutePoint[]
+  ): Waypoint {
+    return {
+      ...waypoint,
+      distanceFromStart: this.calculateDistanceToWaypoint(waypoint, routePoints)
+    }
+  }
+  
+  /**
+   * すべてのWaypointの距離を再計算する
+   * @param waypoints Waypointの配列
+   * @param routePoints ルートポイントの配列
+   * @returns 距離が更新された新しいWaypoint配列
+   */
+  static updateAllWaypointDistances(
+    waypoints: Waypoint[],
+    routePoints: RoutePoint[]
+  ): Waypoint[] {
+    return calculateAllWaypointDistances(waypoints, routePoints)
+  }
+}


### PR DESCRIPTION
## Summary
Issue #42のPhase 3として、ルートとWaypointの距離計算ロジックをドメインレイヤーに分離しました。

## Changes
- `RouteCalculator`クラスを追加
  - ルートポイント間の総距離計算
  - Routeオブジェクトの作成・更新
- `WaypointCalculator`クラスを追加
  - Waypointまでの距離計算
  - Waypoint距離の更新
- `routeStore`のリファクタリング
  - インラインの距離計算ロジックをドメインクラスに委譲
  - storeは純粋な状態管理に専念

## Test plan
- [x] 全テスト（93件）がパスすることを確認
- [x] タイプチェック（`npx tsc -b`）が通ることを確認
- [x] リント（`pnpm lint`）が通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)