### PR TITLE
fix: 編集モードで線分上に点を追加できるように修正

### DIFF
--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -18,7 +18,7 @@ const MapContainer = forwardRef<MapRef, MapContainerProps>(
     const { route } = useRouteStore()
     const { editMode, mapStyle } = useUIStore()
     
-    const shouldShowInteractiveLine = editMode === 'create' && route.points.length > 1
+    const shouldShowInteractiveLine = (editMode === 'create' || editMode === 'edit' || editMode === 'waypoint') && route.points.length > 1
     const selectedStyle = MAP_STYLES[mapStyle]
     
     // Fallback to dark style if selected style has no URL (missing API key)

--- a/src/hooks/useMapHandlers.ts
+++ b/src/hooks/useMapHandlers.ts
@@ -39,7 +39,8 @@ export function useMapHandlers({ mapRef }: UseMapHandlersProps) {
       return
     }
     
-    if (editMode !== 'create') return
+    // Allow line clicks in both create and edit modes
+    if (editMode !== 'create' && editMode !== 'edit') return
     
     // Check if we clicked on the line
     const features = mapRef.current?.queryRenderedFeatures(e.point, {
@@ -59,8 +60,8 @@ export function useMapHandlers({ mapRef }: UseMapHandlersProps) {
         lat: clickPoint.lat,
         lng: clickPoint.lng
       })
-    } else {
-      // Clicked on empty space - add to end
+    } else if (editMode === 'create') {
+      // Clicked on empty space - add to end (only in create mode)
       addPoint({
         lat: e.lngLat.lat,
         lng: e.lngLat.lng
@@ -112,7 +113,7 @@ export function useMapHandlers({ mapRef }: UseMapHandlersProps) {
   }, [route.points, hoveredPointId, setHoveredPoint, getCursorForWaypointMode, mapRef])
   
   const handleMouseEnter = useCallback((e: any) => {
-    if (editMode === 'create' && e.features && e.features.length > 0 && e.features[0].layer.id === 'route-line') {
+    if ((editMode === 'create' || editMode === 'edit') && e.features && e.features.length > 0 && e.features[0].layer.id === 'route-line') {
       e.target.getCanvas().style.cursor = 'pointer'
     } else if (editMode === 'waypoint' && e.features && e.features.length > 0 && e.features[0].layer.id === 'route-line') {
       e.target.getCanvas().style.cursor = 'pointer'


### PR DESCRIPTION
## 概要
Issue #47 を修正しました。編集モードでも線分上をクリックすることで新しい点を追加できるようになります。

## 変更内容
- `handleMapClick`で編集モードでも線分クリックを処理するように変更
- `handleMouseEnter`で編集モードでも線分上でポインターカーソルを表示
- 新規作成モードと同様の操作感を編集モードでも実現

## 動作確認
1. ルートに2つ以上の点を作成
2. 編集モード（緑の鉛筆ボタン）に切り替える
3. 既存の点と点を結ぶ線分上にマウスを移動 → カーソルがポインターに変わる
4. 線分上をクリック → その位置に新しい点が追加される

## 関連Issue
fixes #47

🤖 Generated with [Claude Code](https://claude.ai/code)