### PR TITLE
Issue #49: 端点のホバー検出を修正

### DIFF
--- a/src/hooks/useMapHandlers.ts
+++ b/src/hooks/useMapHandlers.ts
@@ -78,17 +78,17 @@ export function useMapHandlers({ mapRef }: UseMapHandlersProps) {
       mapRef.current.getCanvas().style.cursor = waypointCursor
     }
     
-    // 中間点のホバー処理
-    if (route.points.length <= 2) return
+    // ポイントのホバー処理
+    if (route.points.length === 0) return
     
     const { point } = e
     const threshold: number = MAP_CONSTANTS.HOVER_THRESHOLD_PIXELS
     
-    // Check distance to middle points only
+    // Check distance to all points
     let closestPoint = null
     let minDistance = threshold
     
-    for (let i = 1; i < route.points.length - 1; i++) {
+    for (let i = 0; i < route.points.length; i++) {
       const routePoint = route.points[i]
       const pixel = mapRef.current.project([routePoint.lng, routePoint.lat])
       const distance = Math.sqrt(
@@ -104,11 +104,7 @@ export function useMapHandlers({ mapRef }: UseMapHandlersProps) {
     if (closestPoint) {
       setHoveredPoint(closestPoint.id)
     } else if (hoveredPointId) {
-      // Check if currently hovered point is a middle point
-      const hoveredIndex = route.points.findIndex(p => p.id === hoveredPointId)
-      if (hoveredIndex > 0 && hoveredIndex < route.points.length - 1) {
-        setHoveredPoint(null)
-      }
+      setHoveredPoint(null)
     }
   }, [route.points, hoveredPointId, setHoveredPoint, getCursorForWaypointMode, mapRef])
   


### PR DESCRIPTION
## Summary
- 端点にマウスをホバーしてもポイントが表示されない問題を修正
- 座標計算によるホバー検出で、全てのポイント（端点含む）を対象にするように変更

## Changes
- `handleMouseMove`のホバー検出ループを修正
  - Before: 中間点のみチェック（`i = 1` から `route.points.length - 1`）
  - After: 全ポイントをチェック（`i = 0` から `route.points.length`）

## Test plan
- [x] ルートを作成し、端点（始点・終点）にマウスを近づける
- [x] 端点から20ピクセル以内に近づくとポイントが表示されることを確認
- [x] 中間点のホバー表示も引き続き動作することを確認
- [x] 各編集モードでの動作を確認

Closes #49

🤖 Generated with [Claude Code](https://claude.ai/code)