### PR TITLE
fix: Undoボタンが期待通りに動作しない問題を修正

### DIFF
--- a/src/domain/HistoryManager.ts
+++ b/src/domain/HistoryManager.ts
@@ -20,6 +20,33 @@ interface HistoryUpdate {
  */
 export class HistoryManager {
   /**
+   * 空の履歴に最初の変更を追加
+   */
+  private static createInitialHistory(
+    currentState: CurrentState,
+    currentRoute: Route,
+    currentWaypoints: Waypoint[],
+    newRoute: Route | null,
+    newWaypoints: Waypoint[] | null
+  ): HistoryUpdate {
+    const currentSnapshot = RouteHistoryManager.createSnapshot(
+      currentState.route,
+      currentState.waypoints
+    )
+    const newSnapshot = RouteHistoryManager.createSnapshot(currentRoute, currentWaypoints)
+    
+    const updates: HistoryUpdate = {
+      history: [currentSnapshot, newSnapshot],
+      historyIndex: 1
+    }
+    
+    if (newRoute) updates.route = newRoute
+    if (newWaypoints) updates.waypoints = newWaypoints
+    
+    return updates
+  }
+
+  /**
    * 履歴を更新し、新しい状態の変更を返す
    */
   static updateWithHistory(
@@ -32,21 +59,13 @@ export class HistoryManager {
     
     // 履歴が空の場合、現在の状態を最初の履歴として追加
     if (currentState.history.length === 0) {
-      const currentSnapshot = RouteHistoryManager.createSnapshot(
-        currentState.route,
-        currentState.waypoints
+      return this.createInitialHistory(
+        currentState,
+        currentRoute,
+        currentWaypoints,
+        newRoute,
+        newWaypoints
       )
-      const newSnapshot = RouteHistoryManager.createSnapshot(currentRoute, currentWaypoints)
-      
-      const updates: HistoryUpdate = {
-        history: [currentSnapshot, newSnapshot],
-        historyIndex: 1
-      }
-      
-      if (newRoute) updates.route = newRoute
-      if (newWaypoints) updates.waypoints = newWaypoints
-      
-      return updates
     }
     
     const historyResult = RouteHistoryManager.addToHistory(

--- a/src/domain/HistoryManager.ts
+++ b/src/domain/HistoryManager.ts
@@ -36,15 +36,11 @@ export class HistoryManager {
         currentState.route,
         currentState.waypoints
       )
-      const historyResult = RouteHistoryManager.addToHistory(
-        [currentSnapshot],
-        0,
-        RouteHistoryManager.createSnapshot(currentRoute, currentWaypoints)
-      )
+      const newSnapshot = RouteHistoryManager.createSnapshot(currentRoute, currentWaypoints)
       
       const updates: HistoryUpdate = {
-        history: historyResult.history,
-        historyIndex: historyResult.newIndex
+        history: [currentSnapshot, newSnapshot],
+        historyIndex: 1
       }
       
       if (newRoute) updates.route = newRoute

--- a/src/domain/HistoryManager.ts
+++ b/src/domain/HistoryManager.ts
@@ -30,6 +30,29 @@ export class HistoryManager {
     const currentRoute = newRoute || currentState.route
     const currentWaypoints = newWaypoints || currentState.waypoints
     
+    // 履歴が空の場合、現在の状態を最初の履歴として追加
+    if (currentState.history.length === 0) {
+      const currentSnapshot = RouteHistoryManager.createSnapshot(
+        currentState.route,
+        currentState.waypoints
+      )
+      const historyResult = RouteHistoryManager.addToHistory(
+        [currentSnapshot],
+        0,
+        RouteHistoryManager.createSnapshot(currentRoute, currentWaypoints)
+      )
+      
+      const updates: HistoryUpdate = {
+        history: historyResult.history,
+        historyIndex: historyResult.newIndex
+      }
+      
+      if (newRoute) updates.route = newRoute
+      if (newWaypoints) updates.waypoints = newWaypoints
+      
+      return updates
+    }
+    
     const historyResult = RouteHistoryManager.addToHistory(
       currentState.history,
       currentState.historyIndex,

--- a/src/domain/StateManager.ts
+++ b/src/domain/StateManager.ts
@@ -29,8 +29,8 @@ export class StateManager {
     const emptyState = this.createEmptyState()
     return {
       ...emptyState,
-      history: [emptyState],
-      historyIndex: 0
+      history: [],
+      historyIndex: -1
     }
   }
   

--- a/src/domain/__tests__/HistoryManager.test.ts
+++ b/src/domain/__tests__/HistoryManager.test.ts
@@ -81,5 +81,95 @@ describe('HistoryManager', () => {
         waypoints: mockWaypoints
       })
     })
+    
+    it('should create initial history when history is empty', () => {
+      const emptyHistoryState = {
+        route: { points: [], distance: 0 },
+        waypoints: [],
+        history: [] as HistoryState[],
+        historyIndex: -1
+      }
+      
+      const newRoute: Route = {
+        points: [{ id: '1', lat: 35.6762, lng: 139.6503 }],
+        distance: 0
+      }
+      
+      const result = HistoryManager.updateWithHistory(
+        emptyHistoryState,
+        newRoute,
+        null
+      )
+      
+      // 履歴に2つのエントリが作成されることを確認
+      expect(result.history).toHaveLength(2)
+      expect(result.historyIndex).toBe(1)
+      
+      // 最初のエントリは空の状態
+      expect(result.history[0]).toEqual({
+        route: { points: [], distance: 0 },
+        waypoints: []
+      })
+      
+      // 2番目のエントリは新しい状態
+      expect(result.history[1]).toEqual({
+        route: newRoute,
+        waypoints: []
+      })
+      
+      expect(result.route).toEqual(newRoute)
+    })
+    
+    it('should truncate future history when adding from middle of history', () => {
+      const stateWithLongHistory = {
+        route: mockRoute,
+        waypoints: mockWaypoints,
+        history: [
+          { route: { points: [], distance: 0 }, waypoints: [] },
+          { route: mockRoute, waypoints: [] },
+          { route: mockRoute, waypoints: mockWaypoints },
+          { route: mockRoute, waypoints: [...mockWaypoints, { ...mockWaypoints[0], id: 'w2' }] }
+        ] as HistoryState[],
+        historyIndex: 1  // 現在は2番目の状態
+      }
+      
+      const newRoute: Route = {
+        points: [...mockRoute.points, { id: '3', lat: 35.6820, lng: 139.6450 }],
+        distance: 1500
+      }
+      
+      const result = HistoryManager.updateWithHistory(
+        stateWithLongHistory,
+        newRoute,
+        null
+      )
+      
+      // 未来の履歴は削除され、新しい履歴が追加される
+      expect(result.history).toHaveLength(3)
+      expect(result.historyIndex).toBe(2)
+      expect(result.history[2].route).toEqual(newRoute)
+    })
+    
+    it('should handle both route and waypoints updates simultaneously', () => {
+      const newRoute: Route = {
+        points: [...mockRoute.points, { id: '3', lat: 35.6820, lng: 139.6450 }],
+        distance: 1500
+      }
+      const newWaypoints = [...mockWaypoints, { ...mockWaypoints[0], id: 'w2' }]
+      
+      const result = HistoryManager.updateWithHistory(
+        mockState,
+        newRoute,
+        newWaypoints
+      )
+      
+      expect(result.route).toEqual(newRoute)
+      expect(result.waypoints).toEqual(newWaypoints)
+      expect(result.history).toHaveLength(3)
+      expect(result.history[2]).toEqual({
+        route: newRoute,
+        waypoints: newWaypoints
+      })
+    })
   })
 })

--- a/src/store/routeStore.ts
+++ b/src/store/routeStore.ts
@@ -102,11 +102,11 @@ export const useRouteStore = create<RouteState>((set, get) => {
   },
   
   undo: () => {
-    applyHistoryOperation(RouteHistoryManager.undo)
+    applyHistoryOperation((history, index) => RouteHistoryManager.undo(history, index))
   },
   
   redo: () => {
-    applyHistoryOperation(RouteHistoryManager.redo)
+    applyHistoryOperation((history, index) => RouteHistoryManager.redo(history, index))
   },
   
   clearRoute: () => {


### PR DESCRIPTION
## 概要
issue #59 で報告された、Undoボタンが期待通りに動作しない問題を修正しました。

## 問題
- 初期状態で空の履歴が保存されていた
- 最初のポイント追加後にUndoすると、空の状態に戻ってしまう
- ユーザーは最後に追加したポイントだけが削除されることを期待

## 変更内容
1. **StateManager.ts**
   - 初期状態の履歴を空配列に変更
   - historyIndexを-1に初期化

2. **HistoryManager.ts**
   - 履歴が空の場合の処理を追加
   - 最初の操作時に現在の状態と新しい状態の両方を履歴に追加

## 動作確認
- [x] ビルドエラーなし
- [x] 型チェック通過
- [x] Lintエラーなし

## テスト手順
1. アプリケーションを起動
2. 地図上をクリックしてポイントを追加
3. Undoボタンをクリック
4. 追加したポイントだけが削除されることを確認

Fixes #59

🤖 Generated with [Claude Code](https://claude.ai/code)